### PR TITLE
fix: added support for stacks with more than 100 content types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,11 @@
       },
       "devDependencies": {
         "@oclif/plugin-help": "^3.2.0",
+        "@types/async": "^3.2.18",
         "@types/jest": "^26.0.14",
         "@types/lodash": "^4.14.162",
         "@types/node": "^10.17.28",
+        "async": "^3.2.4",
         "eslint": "^5.16.0",
         "eslint-config-oclif": "^3.1.0",
         "eslint-config-oclif-typescript": "^0.1.0",
@@ -2168,6 +2170,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
+    },
+    "node_modules/@types/async": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.18.tgz",
+      "integrity": "sha512-/IsuXp3B9R//uRLi40VlIYoMp7OzhkunPe2fDu7jGfQXI9y3CDCx6FC4juRLSqrpmLst3vgsiK536AAGJFl4Ww==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "contentstack-cli-tsgen",
+  "name": "@tahzoo/contentstack-cli-tsgen",
   "description": "Generate TypeScript typings from a Stack.",
   "version": "2.1.0",
   "author": "Michael Davis",
@@ -36,7 +36,7 @@
     "/npm-shrinkwrap.json",
     "/oclif.manifest.json"
   ],
-  "homepage": "https://github.com/Contentstack-Solutions/contentstack-cli-tsgen",
+  "homepage": "https://github.com/Tahzoo/contentstack-cli-tsgen",
   "keywords": [
     "contentstack",
     "cli",
@@ -51,7 +51,7 @@
       "@oclif/plugin-help"
     ]
   },
-  "repository": "Contentstack-Solutions/contentstack-cli-tsgen",
+  "repository": "Tahzoo/contentstack-cli-tsgen",
   "scripts": {
     "postpack": "rm -f oclif.manifest.json",
     "posttest": "eslint . --ext .ts --config .eslintrc",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
   },
   "devDependencies": {
     "@oclif/plugin-help": "^3.2.0",
+    "@types/async": "^3.2.18",
     "@types/jest": "^26.0.14",
     "@types/lodash": "^4.14.162",
     "@types/node": "^10.17.28",
+    "async": "^3.2.4",
     "eslint": "^5.16.0",
     "eslint-config-oclif": "^3.1.0",
     "eslint-config-oclif-typescript": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tahzoo/contentstack-cli-tsgen",
+  "name": "contentstack-cli-tsgen",
   "description": "Generate TypeScript typings from a Stack.",
   "version": "2.1.0",
   "author": "Michael Davis",
@@ -36,7 +36,7 @@
     "/npm-shrinkwrap.json",
     "/oclif.manifest.json"
   ],
-  "homepage": "https://github.com/Tahzoo/contentstack-cli-tsgen",
+  "homepage": "https://github.com/Contentstack-Solutions/contentstack-cli-tsgen",
   "keywords": [
     "contentstack",
     "cli",
@@ -51,7 +51,7 @@
       "@oclif/plugin-help"
     ]
   },
-  "repository": "Tahzoo/contentstack-cli-tsgen",
+  "repository": "Contentstack-Solutions/contentstack-cli-tsgen",
   "scripts": {
     "postpack": "rm -f oclif.manifest.json",
     "posttest": "eslint . --ext .ts --config .eslintrc",


### PR DESCRIPTION
This PR adds `async` library for parallel fetching of content types in stackConnect function for stacks with more than 100 content types