### PR TITLE
fix: added support for stacks with more than 100 content types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,11 @@
       },
       "devDependencies": {
         "@oclif/plugin-help": "^3.2.0",
+        "@types/async": "^3.2.18",
         "@types/jest": "^26.0.14",
         "@types/lodash": "^4.14.162",
         "@types/node": "^10.17.28",
+        "async": "^3.2.4",
         "eslint": "^5.16.0",
         "eslint-config-oclif": "^3.1.0",
         "eslint-config-oclif-typescript": "^0.1.0",
@@ -2168,6 +2170,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
+    },
+    "node_modules/@types/async": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.18.tgz",
+      "integrity": "sha512-/IsuXp3B9R//uRLi40VlIYoMp7OzhkunPe2fDu7jGfQXI9y3CDCx6FC4juRLSqrpmLst3vgsiK536AAGJFl4Ww==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.0",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
   },
   "devDependencies": {
     "@oclif/plugin-help": "^3.2.0",
+    "@types/async": "^3.2.18",
     "@types/jest": "^26.0.14",
     "@types/lodash": "^4.14.162",
     "@types/node": "^10.17.28",
+    "async": "^3.2.4",
     "eslint": "^5.16.0",
     "eslint-config-oclif": "^3.1.0",
     "eslint-config-oclif-typescript": "^0.1.0",

--- a/src/lib/stack/client.ts
+++ b/src/lib/stack/client.ts
@@ -44,10 +44,10 @@ export async function stackConnect(client: any, config: StackConnectionConfig) {
 
     if (results.count > limit) {
       const additionalQueries = Array.from(
-        { length: Math.ceil(results.count / limit) - 1 },
+        {length: Math.ceil(results.count / limit) - 1},
         (_, i) => {
           return async.reflect(async () => {
-            return await stack.getContentTypes({
+            return stack.getContentTypes({
               ...queryParams,
               skip: (i + 1) * limit,
             })
@@ -55,15 +55,15 @@ export async function stackConnect(client: any, config: StackConnectionConfig) {
         }
       )
       const additionalResults = (await async.parallel(additionalQueries)) as {
-        value: ContentTypeCollection
+        value: ContentTypeCollection;
       }[]
 
-      additionalResults.map((r) => {
+      for (const r of additionalResults) {
         results.content_types = [
           ...results.content_types,
           ...r.value.content_types,
         ]
-      })
+      }
     }
 
     const types = results.content_types


### PR DESCRIPTION
This PR updates the stackConnect function to add support for type fetching in stacks with more than 100 content types.