### PR TITLE
fix: Fixing syntax error in type_reference fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contentstack-cli-tsgen",
   "description": "Generate TypeScript typings from a Stack.",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "author": "Michael Davis",
   "bugs": "https://github.com/Contentstack-Solutions/contentstack-cli-tsgen/issues",
   "dependencies": {

--- a/src/lib/stack/client.ts
+++ b/src/lib/stack/client.ts
@@ -1,95 +1,95 @@
-import * as http from "https";
-import * as async from "async";
-import { ContentTypeCollection } from "contentstack";
+import * as http from 'https'
+import * as async from 'async'
+import {ContentTypeCollection} from 'contentstack'
 
 type RegionUrlMap = {
   [prop: string]: string;
 };
 
 const REGION_URL_MAPPING: RegionUrlMap = {
-  na: "cdn.contentstack.io",
-  us: "cdn.contentstack.io",
-  eu: "eu-cdn.contentstack.com",
-  "azure-na": "azure-na-cdn.contentstack.com",
-};
+  na: 'cdn.contentstack.io',
+  us: 'cdn.contentstack.io',
+  eu: 'eu-cdn.contentstack.com',
+  'azure-na': 'azure-na-cdn.contentstack.com',
+}
 
 export type StackConnectionConfig = {
   apiKey: string;
   token: string;
   region: any;
   environment: string;
-  branch?: string | null;
-};
+  branch?: string|null;
+}
 
-const limit = 100;
+const limit = 100
 
 const queryParams = {
   limit,
   include_global_field_schema: true,
-};
+}
 
 export async function stackConnect(client: any, config: StackConnectionConfig) {
   try {
-    const clientParams: {
-      api_key: string;
-      delivery_token: string;
-      environment: string;
-      region: string;
-      branch?: string;
+    const clientParams: { 
+      api_key: string,
+      delivery_token: string,
+      environment: string,
+      region: string,
+      branch?: string
     } = {
       api_key: config.apiKey,
       delivery_token: config.token,
       environment: config.environment,
       region: config.region,
-    };
+    }
     if (config.branch) {
-      clientParams.branch = config.branch;
+      clientParams.branch = config.branch
     }
     // eslint-disable-next-line new-cap
-    const stack = client(clientParams);
+    const stack = client(clientParams)
 
     const results = (await stack.getContentTypes({
       ...queryParams,
       include_count: true,
-    })) as Omit<ContentTypeCollection, "count"> & { count: number };
+    })) as Omit<ContentTypeCollection, 'count'> & { count: number }
 
     if (results.count > limit) {
       const additionalQueries = Array.from(
-        { length: Math.ceil(results.count / limit) - 1 },
+        {length: Math.ceil(results.count / limit) - 1},
         (_, i) => {
           return async.reflect(async () => {
             return stack.getContentTypes({
               ...queryParams,
               skip: (i + 1) * limit,
-            });
-          });
+            })
+          })
         }
-      );
+      )
       const additionalResults = (await async.parallel(additionalQueries)) as {
         value: ContentTypeCollection;
-      }[];
+      }[]
 
       for (const r of additionalResults) {
         results.content_types = [
           ...results.content_types,
           ...r.value.content_types,
-        ];
+        ]
       }
     }
 
-    const types = results.content_types;
+    const types = results.content_types
 
     if (stack) {
       return {
         stack,
         types,
-      };
+      }
     }
-    throw new Error("Could not connect to the stack.");
+    throw new Error('Could not connect to the stack.')
   } catch (error) {
     throw new Error(
-      "Could not connect to the stack. Please check your credentials."
-    );
+      'Could not connect to the stack. Please check your credentials.'
+    )
   }
 }
 
@@ -99,44 +99,38 @@ export async function getGlobalFields(config: StackConnectionConfig) {
     return new Promise((resolve, reject) => {
       const options: any = {
         host: (REGION_URL_MAPPING as any)[config.region],
-        path: "v3/global_fields?include_branch=false",
+        path: 'v3/global_fields?include_branch=false',
         port: 443,
-        method: "GET",
+        method: 'GET',
         headers: {
           api_key: config.apiKey,
           access_token: config.token,
           environment: config.environment,
         },
-      };
-      if (config.branch) {
-        options.headers.branch = config.branch;
       }
-      const req = http.request(options, (res) => {
-        res.setEncoding("utf8");
-        let body = "";
-        res.on("data", (chunk) => {
-          body += chunk;
-        });
-        res.on("end", () => {
+      if (config.branch) {
+        options.headers.branch = config.branch
+      }
+      const req = http.request(options, res => {
+        res.setEncoding('utf8')
+        let body = ''
+        res.on('data', chunk => {
+          body += chunk
+        })
+        res.on('end', () => {
           if (res.statusCode === 200) {
-            resolve(JSON.parse(body));
+            resolve(JSON.parse(body))
           } else {
-            reject(
-              new Error(
-                "Could not connect to the stack. Please check your credentials."
-              )
-            );
+            reject(new Error('Could not connect to the stack. Please check your credentials.'))
           }
-        });
-      });
-      req.on("error", (error) => {
-        reject(error);
-      });
-      req.end();
-    });
+        })
+      })
+      req.on('error', error => {
+        reject(error)
+      })
+      req.end()
+    })
   } catch (error) {
-    throw new Error(
-      "Could not connect to the stack. Please check your credentials."
-    );
+    throw new Error('Could not connect to the stack. Please check your credentials.')
   }
 }

--- a/src/lib/stack/client.ts
+++ b/src/lib/stack/client.ts
@@ -1,95 +1,95 @@
-import * as http from 'https'
-import * as async from 'async'
-import {ContentTypeCollection} from 'contentstack'
+import * as http from "https";
+import * as async from "async";
+import { ContentTypeCollection } from "contentstack";
 
 type RegionUrlMap = {
   [prop: string]: string;
 };
 
 const REGION_URL_MAPPING: RegionUrlMap = {
-  na: 'cdn.contentstack.io',
-  us: 'cdn.contentstack.io',
-  eu: 'eu-cdn.contentstack.com',
-  'azure-na': 'azure-na-cdn.contentstack.com',
-}
+  na: "cdn.contentstack.io",
+  us: "cdn.contentstack.io",
+  eu: "eu-cdn.contentstack.com",
+  "azure-na": "azure-na-cdn.contentstack.com",
+};
 
 export type StackConnectionConfig = {
   apiKey: string;
   token: string;
   region: any;
   environment: string;
-  branch?: string|null;
-}
+  branch?: string | null;
+};
 
-const limit = 100
+const limit = 100;
 
 const queryParams = {
   limit,
   include_global_field_schema: true,
-}
+};
 
 export async function stackConnect(client: any, config: StackConnectionConfig) {
   try {
-    const clientParams: { 
-      api_key: string,
-      delivery_token: string,
-      environment: string,
-      region: string,
-      branch?: string
+    const clientParams: {
+      api_key: string;
+      delivery_token: string;
+      environment: string;
+      region: string;
+      branch?: string;
     } = {
       api_key: config.apiKey,
       delivery_token: config.token,
       environment: config.environment,
       region: config.region,
-    }
+    };
     if (config.branch) {
-      clientParams.branch = config.branch
+      clientParams.branch = config.branch;
     }
     // eslint-disable-next-line new-cap
-    const stack = client(clientParams)
+    const stack = client(clientParams);
 
     const results = (await stack.getContentTypes({
       ...queryParams,
       include_count: true,
-    })) as Omit<ContentTypeCollection, 'count'> & { count: number }
+    })) as Omit<ContentTypeCollection, "count"> & { count: number };
 
     if (results.count > limit) {
       const additionalQueries = Array.from(
-        {length: Math.ceil(results.count / limit) - 1},
+        { length: Math.ceil(results.count / limit) - 1 },
         (_, i) => {
           return async.reflect(async () => {
             return stack.getContentTypes({
               ...queryParams,
               skip: (i + 1) * limit,
-            })
-          })
+            });
+          });
         }
-      )
+      );
       const additionalResults = (await async.parallel(additionalQueries)) as {
         value: ContentTypeCollection;
-      }[]
+      }[];
 
       for (const r of additionalResults) {
         results.content_types = [
           ...results.content_types,
           ...r.value.content_types,
-        ]
+        ];
       }
     }
 
-    const types = results.content_types
+    const types = results.content_types;
 
     if (stack) {
       return {
         stack,
         types,
-      }
+      };
     }
-    throw new Error('Could not connect to the stack.')
+    throw new Error("Could not connect to the stack.");
   } catch (error) {
     throw new Error(
-      'Could not connect to the stack. Please check your credentials.'
-    )
+      "Could not connect to the stack. Please check your credentials."
+    );
   }
 }
 
@@ -99,38 +99,44 @@ export async function getGlobalFields(config: StackConnectionConfig) {
     return new Promise((resolve, reject) => {
       const options: any = {
         host: (REGION_URL_MAPPING as any)[config.region],
-        path: 'v3/global_fields?include_branch=false',
+        path: "v3/global_fields?include_branch=false",
         port: 443,
-        method: 'GET',
+        method: "GET",
         headers: {
           api_key: config.apiKey,
           access_token: config.token,
           environment: config.environment,
         },
-      }
+      };
       if (config.branch) {
-        options.headers.branch = config.branch
+        options.headers.branch = config.branch;
       }
-      const req = http.request(options, res => {
-        res.setEncoding('utf8')
-        let body = ''
-        res.on('data', chunk => {
-          body += chunk
-        })
-        res.on('end', () => {
+      const req = http.request(options, (res) => {
+        res.setEncoding("utf8");
+        let body = "";
+        res.on("data", (chunk) => {
+          body += chunk;
+        });
+        res.on("end", () => {
           if (res.statusCode === 200) {
-            resolve(JSON.parse(body))
+            resolve(JSON.parse(body));
           } else {
-            reject(new Error('Could not connect to the stack. Please check your credentials.'))
+            reject(
+              new Error(
+                "Could not connect to the stack. Please check your credentials."
+              )
+            );
           }
-        })
-      })
-      req.on('error', error => {
-        reject(error)
-      })
-      req.end()
-    })
+        });
+      });
+      req.on("error", (error) => {
+        reject(error);
+      });
+      req.end();
+    });
   } catch (error) {
-    throw new Error('Could not connect to the stack. Please check your credentials.')
+    throw new Error(
+      "Could not connect to the stack. Please check your credentials."
+    );
   }
 }

--- a/src/lib/tsgen/factory.ts
+++ b/src/lib/tsgen/factory.ts
@@ -291,6 +291,8 @@ export default function (userOptions: TSGenOptions) {
       field.reference_to.forEach(v => {
         references.push(name_type(v))
       })
+    } else {
+      references.push(field.reference_to)
     }
 
     return ['(', references.join(' | '), ')', '[]'].join('')

--- a/src/lib/tsgen/factory.ts
+++ b/src/lib/tsgen/factory.ts
@@ -292,7 +292,7 @@ export default function (userOptions: TSGenOptions) {
         references.push(name_type(v))
       })
     } else {
-      references.push(field.reference_to)
+      references.push(name_type(field.reference_to))
     }
 
     return ['(', references.join(' | '), ')', '[]'].join('')


### PR DESCRIPTION
Closes #30 and #1 

We had this issue where the `type_reference` field _could_ be an array, but also could be a string. This wasn't handled and caused the tsgen to break.

~Additionally, the `getContentTypes` query doesn't paginate, so if you have over 100 types in your stack you'll never get them all. This has now been fixed with a dynamic loop~ 