### PR TITLE
Add support for Azure EU region

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contentstack-cli-tsgen",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "contentstack-cli-tsgen",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "^1.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contentstack-cli-tsgen",
   "description": "Generate TypeScript typings from a Stack.",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "author": "Michael Davis",
   "bugs": "https://github.com/Contentstack-Solutions/contentstack-cli-tsgen/issues",
   "dependencies": {

--- a/src/lib/stack/client.ts
+++ b/src/lib/stack/client.ts
@@ -11,6 +11,7 @@ const REGION_URL_MAPPING: RegionUrlMap = {
   us: 'cdn.contentstack.io',
   eu: 'eu-cdn.contentstack.com',
   'azure-na': 'azure-na-cdn.contentstack.com',
+  'azure-eu': 'azure-eu-cdn.contentstack.com',
 }
 
 export type StackConnectionConfig = {
@@ -30,7 +31,7 @@ const queryParams = {
 
 export async function stackConnect(client: any, config: StackConnectionConfig) {
   try {
-    const clientParams: { 
+    const clientParams: {
       api_key: string,
       delivery_token: string,
       environment: string,


### PR DESCRIPTION
Update the client config to support type generation against the APIs that are hosted in the Azure EU region.