### PR TITLE
Added the version info in generated types for both content type and global field. Version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contentstack-cli-tsgen",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "contentstack-cli-tsgen",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "^1.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contentstack-cli-tsgen",
   "description": "Generate TypeScript typings from a Stack.",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "author": "Michael Davis",
   "bugs": "https://github.com/Contentstack-Solutions/contentstack-cli-tsgen/issues",
   "dependencies": {

--- a/src/lib/stack/schema.ts
+++ b/src/lib/stack/schema.ts
@@ -27,6 +27,7 @@ export type Block = {
 export type GlobalField = {
   reference_to: string;
   schema: Schema;
+  _version?: number
 } & FieldOptions;
 
 export type ReferenceField = {

--- a/src/lib/tsgen/factory.ts
+++ b/src/lib/tsgen/factory.ts
@@ -228,6 +228,8 @@ export default function (userOptions: TSGenOptions) {
       options.docgen.interface(contentType.description),
       define_interface(contentType),
       '{',
+      ['/**', "Version", '*/'].join(' '),
+      [`version: `,contentType._version].join(' '),
       visit_fields(contentType.schema),
       '}',
     ]


### PR DESCRIPTION
Version Bump: 2.1.7